### PR TITLE
fix: silence util extend deprecation and handle proxy errors

### DIFF
--- a/src/application/server.ts
+++ b/src/application/server.ts
@@ -15,9 +15,8 @@ function logger(context: string, message: string, color: (s: string) => string =
 export async function startServer(cfg: Config) {
   // Avoid Node deprecation warning by replacing the deprecated util._extend
   // used by the http-proxy dependency with Object.assign before requiring it.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ((util as any)._extend) {
-    (util as any)._extend = Object.assign;
+  if ('_extend' in util) {
+    (util as typeof util & { _extend?: typeof Object.assign })._extend = Object.assign;
   }
 
   // Load http-proxy-middleware after patching util._extend.

--- a/src/application/server.ts
+++ b/src/application/server.ts
@@ -38,20 +38,17 @@ export async function startServer(cfg: Config) {
         const msg = `${req.method} ${req.originalUrl} -> ${dest}`;
         if (cfg.log) logger('Request', msg, color);
         logToFile(node, `${new Date().toISOString()} ${msg}`);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (req as any)._startAt = Date.now();
+        requestTimings.set(req, Date.now()); // Store start time in WeakMap
       },
       onProxyRes: (proxyRes, req) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const start = (req as any)._startAt || Date.now();
+        const start = requestTimings.get(req) || Date.now(); // Retrieve start time
         const ms = Date.now() - start;
         const msg = `${req.method} ${req.originalUrl} ${proxyRes.statusCode} +${ms}ms`;
         if (cfg.log) logger('Response', msg, color);
         logToFile(node, `${new Date().toISOString()} ${msg}`);
       },
       onError: (err, _req, res) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const start = (_req as any)._startAt || Date.now();
+        const start = requestTimings.get(_req) || Date.now(); // Retrieve start time
         const ms = Date.now() - start;
         const msg = `${_req.method} ${_req.originalUrl} 502 +${ms}ms`;
         if (cfg.log) logger('Response', msg, color);


### PR DESCRIPTION
## Summary
- avoid Node util._extend deprecation by patching only when the property exists
- log proxy failures and respond with a clear 502 message when upstream services are unreachable
- print request and response details in a NestJS-style format via a generic `logger` helper

## Testing
- `npm run build`
- `npm test`
- `npx proxy start -p 3000 --node auth --destiny http://localhost:9001/auth --node payments --destiny http://localhost:9001/payments --log --save test`
- `curl -i http://localhost:3000/auth/me`


------
https://chatgpt.com/codex/tasks/task_e_688c527fc6d08332870adae1cc5d0e44