### PR TITLE
feat: add configurable cors support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,12 @@ its destination:
     "auth": "http://localhost:9001/auth",
     "invoices": "http://localhost:9002/invoices"
   },
-  "log": true
+  "log": true,
+  "cors": {
+    "origin": ["http://example.com"],
+    "methods": ["GET"],
+    "allowedHeaders": ["Content-Type"]
+  }
 }
 ```
 
@@ -83,6 +88,10 @@ npx proxy.sh logs auth
 - `-s, --save`      Save provided/interactive options as configuration.
 - `--log`           Enable console request logging.
 - `--daemon`        Run in background.
+- `--cors`          Enable CORS.
+- `--cors-origin`   Allowed CORS origin (repeatable).
+- `--cors-method`   Allowed CORS method (repeatable).
+- `--cors-header`   Allowed CORS header (repeatable).
 For viewing logs use:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "proxy.sh",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxy.sh",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^11.0.0",
+        "cors": "^2.8.5",
         "express": "^4.18.2",
         "http-proxy-middleware": "^2.0.6",
         "inquirer": "^9.2.7"
@@ -19,6 +20,7 @@
         "proxy": "dist/cli/index.js"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/jest": "^29.5.11",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
@@ -1189,6 +1191,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -2002,6 +2014,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -4659,6 +4684,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^11.0.0",
+    "cors": "^2.8.5",
     "express": "^4.18.2",
     "http-proxy-middleware": "^2.0.6",
     "inquirer": "^9.2.7"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/jest": "^29.5.11",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",

--- a/src/application/server.ts
+++ b/src/application/server.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import chalk from 'chalk';
+import cors from 'cors';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import type { Server } from 'http';
 import { Config } from '../domain/config';
@@ -7,6 +8,13 @@ import { logToFile } from '../domain/logs';
 
 export async function startServer(cfg: Config): Promise<Server> {
   const app = express();
+  if (cfg.cors) {
+    const corsOptions: any = {};
+    if (cfg.cors.origin) corsOptions.origin = cfg.cors.origin;
+    if (cfg.cors.methods) corsOptions.methods = cfg.cors.methods;
+    if (cfg.cors.allowedHeaders) corsOptions.allowedHeaders = cfg.cors.allowedHeaders;
+    app.use(cors(corsOptions));
+  }
   const colors = [chalk.cyan, chalk.magenta, chalk.yellow, chalk.green];
 
   Object.entries(cfg.nodes).forEach(([node, dest], idx) => {

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -16,6 +16,10 @@ export function makeStartCommand(): Command {
     .option('-s, --save <file>', 'Save config under given name')
     .option('--log', 'Enable request logging')
     .option('--daemon', 'Run in background')
+    .option('--cors', 'Enable CORS')
+    .option('--cors-origin <origin>', 'Allowed CORS origin', collect, [])
+    .option('--cors-method <method>', 'Allowed CORS method', collect, [])
+    .option('--cors-header <header>', 'Allowed CORS header', collect, [])
     .addHelpText('after', `\nExamples:\n` +
       `  $ npx proxy start -p 8000 --node auth:http://localhost:9000 --node products:http://localhost:9001\n` +
       `  $ npx proxy start --save myconfig\n` +
@@ -69,6 +73,12 @@ export function makeStartCommand(): Command {
       cfg.log = opts.log ?? cfg.log;
       if (Object.keys(argRoutes).length) cfg.nodes = argRoutes;
     }
+
+    const cors: any = {};
+    if (opts.corsOrigin && opts.corsOrigin.length) cors.origin = opts.corsOrigin;
+    if (opts.corsMethod && opts.corsMethod.length) cors.methods = opts.corsMethod;
+    if (opts.corsHeader && opts.corsHeader.length) cors.allowedHeaders = opts.corsHeader;
+    if (opts.cors || Object.keys(cors).length) cfg.cors = cors;
 
     if (Object.keys(cfg.nodes).length === 0) {
       console.error('At least one node mapping must be provided');

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -2,10 +2,17 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
+export interface CorsConfig {
+  origin?: string[];
+  methods?: string[];
+  allowedHeaders?: string[];
+}
+
 export interface Config {
   port: number;
   nodes: Record<string, string>;
   log?: boolean;
+  cors?: CorsConfig;
 }
 
 export function resolveConfigPath(name: string): string {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -35,6 +35,7 @@ describe('startServer', () => {
         invoices: 'http://localhost:9002/invoices',
       },
       log: false,
+      cors: { origin: ['http://example.com'], methods: ['GET'] },
     });
   });
 
@@ -50,5 +51,12 @@ describe('startServer', () => {
 
     const r2 = await fetch('http://localhost:3100/invoices/test');
     expect(await r2.text()).toBe('invoices');
+  });
+
+  it('applies CORS headers when enabled', async () => {
+    const res = await fetch('http://localhost:3100/auth/test', {
+      headers: { Origin: 'http://example.com' }
+    });
+    expect(res.headers.get('access-control-allow-origin')).toBe('http://example.com');
   });
 });


### PR DESCRIPTION
## Summary
- allow enabling CORS and configuring allowed origins, methods and headers via CLI flags
- apply CORS middleware on server when configured
- document new CORS options and update example configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68910a6cd8948332a482664b2d8e36c0