### PR TITLE
fix: forward path prefix to target

### DIFF
--- a/dist/application/server.js
+++ b/dist/application/server.js
@@ -37,7 +37,7 @@ async function startServer(cfg) {
         const options = {
             target: dest,
             changeOrigin: true,
-            pathRewrite: (p) => p.replace(new RegExp('^' + prefix), ''),
+            pathRewrite: { [`^${prefix}`]: '' },
         };
         if (cfg.log) {
             const displayOptions = {
@@ -47,7 +47,7 @@ async function startServer(cfg) {
             };
             console.log(color(`Proxy config for ${prefix}: ${JSON.stringify(displayOptions, null, 2)}`));
         }
-        app.use((0, http_proxy_middleware_1.createProxyMiddleware)(prefix, {
+        app.use(prefix, (0, http_proxy_middleware_1.createProxyMiddleware)({
             ...options,
             onProxyReq: (_, req) => {
                 const msg = `${req.method} ${req.originalUrl} \u2192 ${dest}`;

--- a/src/application/server.ts
+++ b/src/application/server.ts
@@ -36,7 +36,7 @@ export async function startServer(cfg: Config): Promise<Server> {
     const options = {
       target: dest,
       changeOrigin: true,
-      pathRewrite: (p: string) => p.replace(new RegExp('^' + prefix), ''),
+      pathRewrite: { [`^${prefix}`]: '' },
     };
 
     if (cfg.log) {
@@ -48,7 +48,7 @@ export async function startServer(cfg: Config): Promise<Server> {
       console.log(color(`Proxy config for ${prefix}: ${JSON.stringify(displayOptions, null, 2)}`));
     }
 
-    app.use(createProxyMiddleware(prefix, {
+    app.use(prefix, createProxyMiddleware({
       ...options,
       onProxyReq: (_, req) => {
         const msg = `${req.method} ${req.originalUrl} \u2192 ${dest}`;


### PR DESCRIPTION
## Summary
- ensure proxy middleware is mounted under each node's prefix and strip the prefix before forwarding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68911a14c6f08332afc5c62d508796ec